### PR TITLE
avoid unused return value warning

### DIFF
--- a/src/v8-promise.cc
+++ b/src/v8-promise.cc
@@ -46,7 +46,7 @@ Local<Promise> WebRTC::CreatePromise(Isolate *isolate,
     Nan::HandleScope scope;
     Local<Promise::Resolver> resolver = Nan::New(*persistent);
 
-    resolver->Resolve(Nan::GetCurrentContext(), result);
+    (void)resolver->Resolve(Nan::GetCurrentContext(), result);
     Isolate::GetCurrent()->RunMicrotasks();
     
     if (reflock) {
@@ -61,9 +61,9 @@ Local<Promise> WebRTC::CreatePromise(Isolate *isolate,
     Local<Promise::Resolver> resolver = Nan::New(*persistent);
 
     if (!error.IsEmpty()) {
-      resolver->Reject(Nan::GetCurrentContext(), Nan::Error(error->Message().c_str()));
+      (void)resolver->Reject(Nan::GetCurrentContext(), Nan::Error(error->Message().c_str()));
     } else {
-      resolver->Reject(Nan::GetCurrentContext(), Nan::Undefined());
+      (void)resolver->Reject(Nan::GetCurrentContext(), Nan::Undefined());
     }
 
     Isolate::GetCurrent()->RunMicrotasks();


### PR DESCRIPTION
full warning:
`warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]`

with this fix the `v2.x` branch is built correctly on node v8.5.0 (Mac)

@vmolsa can you merge and publish v2.0.1 with binaries?
i can generate binaries for NODE_MODULE_VERSION 57 for linux and darwin if needed